### PR TITLE
(fix) reduce menu height on mobile

### DIFF
--- a/src/molecules/main-menu.jsx
+++ b/src/molecules/main-menu.jsx
@@ -46,10 +46,12 @@ const _MainMenu = ({ documentData, locale }: Props) => {
   }
 
   function toggleMainMenu() {
+    const pageOverlay = document.querySelector(".page-overlay");
     let mainMenuButton = mainMenuToggleRef.current;
 
     if (mainMenuButton) {
       mainMenuButton.classList.toggle("expanded");
+      pageOverlay.classList.toggle("hidden");
       setShowMainMenu(!showMainMenu);
     }
   }

--- a/src/molecules/main-menu.scss
+++ b/src/molecules/main-menu.scss
@@ -2,7 +2,7 @@
 @import "~mdn-minimalist/sass/vars/media-queries";
 @import "~mdn-minimalist/sass/vars/typography";
 
-$menu-zindex: 95;
+$menu-zindex: 500;
 $menu-box-shadow: 0 2px 8px 0 $neutral-500;
 $menu-border: solid 1px $neutral-400;
 $menu-border-radius: 4px;
@@ -41,7 +41,6 @@ ul.main-menu {
   padding: 20px;
   padding-top: 0;
   width: 100%;
-  height: 100vh;
   font-weight: bold;
   z-index: $menu-zindex;
 

--- a/src/organisms/header.stories.js
+++ b/src/organisms/header.stories.js
@@ -8,4 +8,9 @@ export default {
   decorators: [withA11y]
 };
 
-export const header = () => <Header />;
+export const header = () => (
+  <>
+    <Header />
+    <div className="page-overlay hidden"></div>
+  </>
+);


### PR DESCRIPTION
Reduce the height of the expanded main menu on mobile. Also
adds a page overlay to gray out the underlying page while
the menu is visible.

fix #170